### PR TITLE
Comentarios más extensos

### DIFF
--- a/dondominio/dondomcli.conf
+++ b/dondominio/dondomcli.conf
@@ -13,17 +13,21 @@
 
 DDUSER=""
 
-# Clave api de DonDominio
-# Para cambiarla / borrarla ir al panel de DonDominio 
-# "Administrar" => "Mi cuenta" => "API externa"
+# Clave DonDNS de DonDominio
+# Para cambiarla / desactivarla ir al panel de DonDominio 
+# "Mi cuenta" => "DonDNS KEY"
 
 DDPASSWORD=""
 
-# Debe descomentarse y ponerse una IP fija
+# Si no se indica una IP concreta, se aplicará la IP pública 
+# desde donde se lanza la ejecución de este script. En el caso
+# que desees aplicar una IP fija, descomenta la siguiente linea
+# e indica la IP
 
 #DDIP=""
 
-# Puede ponerse un host por defecto o pasarlo por linea de comandos
-# Pueden utilizarse varios hosts, separados por ","
+# El campo de la Zona DNS que se pretende actualizar. Puede 
+# ponerse un host por defecto o pasarlo por linea de comandos.
+# También se pueden utilizarse varios hosts, separados por ","
 
 DDHOST=""


### PR DESCRIPTION
Se amplían los comentarios para evitar confusión entre la DonDNS KEY y la clave API de DonDominio.